### PR TITLE
Add full-stack business landing page generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# evil
-generator website
+# Générateur de page d'accueil locale
+
+Ce projet full-stack crée automatiquement une landing page moderne pour une entreprise locale à partir de sa fiche Google Maps. Il se compose d'un backend Node.js/Express chargé du scraping via Puppeteer et d'un frontend React/TypeScript (Vite + TailwindCSS) pour l'interface utilisateur.
+
+## Structure du projet
+
+```
+.
+├── backend        # API Express + Puppeteer
+└── frontend       # Application React + Vite + Tailwind
+```
+
+## Mise en route
+
+### Backend (Node.js / Express / Puppeteer)
+
+1. Installer les dépendances :
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Lancer le serveur en production :
+   ```bash
+   npm start
+   ```
+3. Pour un rechargement automatique en développement :
+   ```bash
+   npm run dev
+   ```
+
+Le serveur écoute par défaut sur [http://localhost:4000](http://localhost:4000) et expose l'endpoint `POST /api/generate-site`.
+
+### Frontend (React / Vite / TailwindCSS)
+
+1. Installer les dépendances :
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Lancer le serveur de développement :
+   ```bash
+   npm run dev
+   ```
+3. Compiler pour la production :
+   ```bash
+   npm run build
+   ```
+4. Prévisualiser le build :
+   ```bash
+   npm run preview
+   ```
+
+Par défaut, Vite démarre sur [http://localhost:5173](http://localhost:5173). Définissez la variable d'environnement `VITE_API_BASE_URL` dans le frontend si l'API backend n'est pas accessible via `http://localhost:4000`.
+
+## Fonctionnement
+
+1. L'utilisateur saisit le nom d'une entreprise dans l'interface React.
+2. Le frontend appelle l'API `/api/generate-site` en lui transmettant le nom.
+3. Le backend lance Puppeteer en mode headless, recherche la fiche Google Maps correspondante, collecte les informations clés (description, contact, horaires, photos `lh3.googleusercontent.com`, etc.) puis renvoie un objet JSON structuré (`BusinessInfo`).
+4. Le frontend injecte ces données dans un template HTML Tailwind moderne et affiche l'aperçu final dans un iframe, avec la possibilité de télécharger le fichier généré.
+
+## Notes importantes
+
+- Le scraping de Google peut nécessiter des ajustements en fonction des changements d'interface ou d'éventuelles pages de consentement. Les sélecteurs utilisés ont été pensés pour couvrir les cas les plus courants.
+- Puppeteer nécessite certaines dépendances système (politiques de sandbox). Sur certains environnements (containers, CI), l'utilisation des options `--no-sandbox` et `--disable-setuid-sandbox` peut être indispensable.
+- Assurez-vous que le backend dispose des autorisations réseau nécessaires pour accéder à Google.
+
+Bonne génération de landing pages !

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,34 @@
+import express from 'express';
+import cors from 'cors';
+import { scrapeBusinessInfo } from './scraper.js';
+
+const app = express();
+const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
+
+app.use(cors());
+app.use(express.json({ limit: '1mb' }));
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.post('/api/generate-site', async (req, res) => {
+  try {
+    const { businessName } = req.body ?? {};
+
+    if (!businessName || typeof businessName !== 'string' || businessName.trim().length === 0) {
+      return res.status(400).json({ error: 'Le champ "businessName" est requis.' });
+    }
+
+    const info = await scrapeBusinessInfo(businessName.trim());
+    return res.status(200).json(info);
+  } catch (error) {
+    console.error('Erreur lors de la génération du site :', error);
+    const message = error instanceof Error ? error.message : 'Erreur serveur inconnue';
+    return res.status(500).json({ error: message });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Serveur backend démarré sur http://localhost:${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "local-business-site-backend",
+  "version": "1.0.0",
+  "description": "Express server with Puppeteer scraping to generate local business landing pages",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "puppeteer": "^21.6.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  }
+}

--- a/backend/scraper.js
+++ b/backend/scraper.js
@@ -1,0 +1,256 @@
+import puppeteer from 'puppeteer';
+
+const GOOGLE_URL = 'https://www.google.com';
+const MAPS_HOST_IDENTIFIER = 'https://maps.google.';
+
+const inputSelectors = ['input[name="q"]', 'textarea[name="q"]'];
+const consentSelectors = [
+  '#L2AGLb',
+  'button[aria-label^="Accepter"]',
+  'button[aria-label*="j\'accepte"]',
+  'button[aria-label^="Accept"]',
+  'button[aria-label^="Ich stimme zu"]',
+  'form[action*="consent"] button[type="submit"]'
+];
+
+async function tryClick(page, selectors, options = {}) {
+  for (const selector of selectors) {
+    const handle = await page.$(selector);
+    if (handle) {
+      await handle.click(options);
+      await page.waitForTimeout(500);
+      await handle.dispose();
+      return true;
+    }
+  }
+  return false;
+}
+
+async function getTextContent(page, selectors) {
+  for (const selector of selectors) {
+    const handle = await page.$(selector);
+    if (handle) {
+      const text = await page.evaluate((el) => el.textContent || '', handle);
+      await handle.dispose();
+      if (text && text.trim().length > 0) {
+        return text.trim();
+      }
+    }
+  }
+  return '';
+}
+
+async function getAttribute(page, selectors, attribute) {
+  for (const selector of selectors) {
+    const handle = await page.$(selector);
+    if (handle) {
+      const value = await page.evaluate((el, attr) => el.getAttribute(attr) || '', handle, attribute);
+      await handle.dispose();
+      if (value && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+  }
+  return '';
+}
+
+function sanitizeNumber(value) {
+  if (!value) return null;
+  const normalized = value.replace(/[^0-9.,]/g, '').replace(',', '.');
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function expandHoursSection(page) {
+  const selectors = [
+    'button[aria-label*="Horaires"]',
+    'button[aria-label*="Hours"]',
+    'button[jsaction*="pane.hours"]',
+    'div[aria-label*="Horaires"] button',
+    'div[aria-label*="Hours"] button'
+  ];
+  await tryClick(page, selectors, { delay: 200 });
+  await page.waitForTimeout(1200);
+}
+
+async function extractHours(page) {
+  const hours = await page.evaluate(() => {
+    const result = [];
+    const containers = [
+      document.querySelector('div[aria-label*="Horaires"] table'),
+      document.querySelector('div[aria-label*="Horaires"]'),
+      document.querySelector('div[aria-label*="Hours"] table'),
+      document.querySelector('div[aria-label*="Hours"]')
+    ];
+
+    for (const container of containers) {
+      if (!container) continue;
+      const rows = container.querySelectorAll('tr');
+      if (rows.length > 0) {
+        rows.forEach((row) => {
+          const cells = row.querySelectorAll('td, th');
+          if (cells.length >= 2) {
+            const day = cells[0].textContent?.trim();
+            const hoursValue = cells[1].textContent?.trim();
+            if (day) {
+              result.push({ day, hours: hoursValue || null });
+            }
+          } else {
+            const text = row.textContent?.trim();
+            if (text) {
+              const [day, ...rest] = text.split(':');
+              result.push({ day: day.trim(), hours: rest.join(':').trim() || null });
+            }
+          }
+        });
+        break;
+      }
+
+      const listItems = container.querySelectorAll('li');
+      if (listItems.length > 0) {
+        listItems.forEach((item) => {
+          const dayElement = item.querySelector('div:first-child');
+          const hourElement = item.querySelector('div:nth-child(2)');
+          const day = dayElement?.textContent?.trim();
+          const hoursValue = hourElement?.textContent?.trim();
+          if (day) {
+            result.push({ day, hours: hoursValue || null });
+          }
+        });
+        break;
+      }
+    }
+
+    return result;
+  });
+
+  return hours.filter((entry) => entry.day);
+}
+
+async function collectPhotoUrls(page) {
+  const photoTriggers = [
+    'button[aria-label*="Photos"]',
+    'button[jsaction*="pane.heroHeader.photo"]',
+    'div[aria-label*="Photo"]',
+    'button[aria-label*="Voir les photos"]',
+    'button[aria-label*="All photos"]'
+  ];
+
+  const opened = await tryClick(page, photoTriggers, { delay: 150 });
+  if (!opened) {
+    return [];
+  }
+
+  try {
+    await page.waitForSelector('div[role="dialog"]', { timeout: 10000 });
+    const scrollableSelector = 'div[role="dialog"] div[role="region"], div[role="dialog"] div[aria-label]';
+
+    for (let i = 0; i < 6; i += 1) {
+      await page.evaluate((selector) => {
+        const scrollable = document.querySelector(selector);
+        if (scrollable) {
+          scrollable.scrollBy(0, scrollable.scrollHeight);
+        }
+      }, scrollableSelector);
+      await page.waitForTimeout(750);
+    }
+
+    const urls = await page.$$eval('div[role="dialog"] img', (images) => {
+      const srcValues = images
+        .map((img) => [img.getAttribute('src'), img.getAttribute('data-src'), img.getAttribute('srcset')])
+        .flat()
+        .filter((value) => typeof value === 'string')
+        .map((value) => value.split(' ')[0]);
+
+      return Array.from(new Set(srcValues)).filter((url) => url.includes('lh3.googleusercontent.com'));
+    });
+
+    await page.keyboard.press('Escape');
+
+    return urls.slice(0, 20);
+  } catch (error) {
+    console.warn('Impossible de récupérer les photos :', error);
+    return [];
+  }
+}
+
+export async function scrapeBusinessInfo(businessName) {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    defaultViewport: { width: 1280, height: 720 }
+  });
+
+  const page = await browser.newPage();
+  await page.setUserAgent(
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36'
+  );
+
+  try {
+    await page.goto(GOOGLE_URL, { waitUntil: 'networkidle2', timeout: 45000 });
+    await tryClick(page, consentSelectors);
+
+    let inputFound = false;
+    for (const selector of inputSelectors) {
+      const input = await page.$(selector);
+      if (input) {
+        await input.click({ clickCount: 3 });
+        await input.type(businessName, { delay: 75 });
+        inputFound = true;
+        await Promise.all([
+          page.waitForNavigation({ waitUntil: 'networkidle2', timeout: 45000 }),
+          page.keyboard.press('Enter')
+        ]);
+        break;
+      }
+    }
+
+    if (!inputFound) {
+      throw new Error('Champ de recherche Google introuvable.');
+    }
+
+    await page.waitForTimeout(2000);
+
+    const mapsLink = await page.evaluate((hostIdentifier) => {
+      const anchors = Array.from(document.querySelectorAll('a[href]'));
+      const mapsAnchor = anchors.find((anchor) => anchor.href.startsWith(hostIdentifier));
+      return mapsAnchor ? mapsAnchor.href : '';
+    }, MAPS_HOST_IDENTIFIER);
+
+    if (!mapsLink) {
+      throw new Error("Impossible de trouver la fiche Google Maps pour cette entreprise.");
+    }
+
+    await page.goto(mapsLink, { waitUntil: 'networkidle2', timeout: 60000 });
+    await page.waitForTimeout(4000);
+
+    await expandHoursSection(page);
+
+    const name = await getTextContent(page, ['h1[class*="DUwDvf"]', 'h1.fontHeadlineLarge']);
+    const description = await getTextContent(page, ['div[role="region"] div[aria-label*="Résumé"] span', 'div[data-section-id="summary"] div.Io6YTe']);
+    const category = await getTextContent(page, ['button[jsaction*="pane.rating.category"] span', 'div[aria-label*="Catégorie"] span']);
+    const address = await getTextContent(page, ['button[data-item-id*="address"] div[role="text"]', 'div[data-item-id*="address"]']);
+    const phone = await getTextContent(page, ['button[data-item-id*="phone"] div[role="text"]', 'div[data-item-id*="phone"]']);
+    const ratingText = await getTextContent(page, ['div.F7nice span[aria-hidden="true"]', 'span[aria-label*="étoiles"]', 'span[aria-label*="stars"]']);
+    const reviewCountText = await getTextContent(page, ['div.F7nice span[role="img"] + span', 'span[aria-label*="avis"]', 'span[aria-label*="reviews"]']);
+
+    const hours = await extractHours(page);
+    const photoUrls = await collectPhotoUrls(page);
+    const mapsUrl = page.url();
+
+    return {
+      name: name || businessName,
+      description: description || '',
+      category: category || '',
+      address: address || '',
+      phone: phone || '',
+      rating: sanitizeNumber(ratingText),
+      reviewCount: sanitizeNumber(reviewCountText),
+      hours,
+      photoUrls,
+      mapsUrl
+    };
+  } finally {
+    await browser.close();
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>Générateur de page d'accueil locale</title>
+  </head>
+  <body class="bg-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "local-business-site-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.3",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.11"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,107 @@
+import { useMemo, useState } from 'react';
+import SearchBar from './components/SearchBar';
+import LoadingSpinner from './components/LoadingSpinner';
+import SitePreview from './components/SitePreview';
+import { BusinessInfo, populateTemplate } from './utils/template';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000';
+
+function App() {
+  const [query, setQuery] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [generatedHtml, setGeneratedHtml] = useState<string | null>(null);
+  const [businessInfo, setBusinessInfo] = useState<BusinessInfo | null>(null);
+
+  const handleGenerate = async () => {
+    if (!query.trim()) {
+      setError('Veuillez saisir un nom d\'entreprise.');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setGeneratedHtml(null);
+    setBusinessInfo(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/generate-site`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ businessName: query.trim() })
+      });
+
+      const payload = (await response.json()) as BusinessInfo & { error?: string };
+
+      if (!response.ok) {
+        throw new Error(payload?.error || 'Une erreur inattendue est survenue.');
+      }
+
+      const html = populateTemplate(payload);
+      setBusinessInfo(payload);
+      setGeneratedHtml(html);
+    } catch (err) {
+      console.error(err);
+      const message = err instanceof Error ? err.message : 'Impossible de générer le site.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const reset = () => {
+    setQuery('');
+    setGeneratedHtml(null);
+    setBusinessInfo(null);
+    setError(null);
+  };
+
+  const headerSubtitle = useMemo(() => {
+    if (businessInfo) {
+      return `Landing page générée pour ${businessInfo.name}`;
+    }
+    return "Générez une page d'accueil moderne à partir d'une fiche Google Maps.";
+  }, [businessInfo]);
+
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <header className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 py-16 text-center text-white">
+        <div className="mx-auto max-w-3xl px-6">
+          <p className="text-sm font-semibold uppercase tracking-[0.4em] text-amber-400">Générateur</p>
+          <h1 className="mt-4 text-4xl font-semibold sm:text-5xl">Créateur de page d'accueil locale</h1>
+          <p className="mt-6 text-lg text-slate-200">{headerSubtitle}</p>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-5xl px-6 py-12">
+        {!generatedHtml && !isLoading && (
+          <SearchBar
+            query={query}
+            onQueryChange={setQuery}
+            onSubmit={handleGenerate}
+          />
+        )}
+
+        {isLoading && (
+          <div className="mt-12 flex justify-center">
+            <LoadingSpinner label="Extraction des données en cours..." />
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-8 rounded-xl border border-rose-200 bg-rose-50 px-6 py-4 text-rose-700">
+            {error}
+          </div>
+        )}
+
+        {generatedHtml && businessInfo && (
+          <SitePreview html={generatedHtml} info={businessInfo} onReset={reset} />
+        )}
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,12 @@
+interface LoadingSpinnerProps {
+  label?: string;
+}
+
+const LoadingSpinner = ({ label }: LoadingSpinnerProps) => (
+  <div className="flex flex-col items-center gap-4">
+    <span className="inline-flex h-12 w-12 animate-spin rounded-full border-4 border-amber-400 border-t-transparent"></span>
+    {label && <p className="text-sm text-slate-600">{label}</p>}
+  </div>
+);
+
+export default LoadingSpinner;

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,0 +1,49 @@
+import { FormEvent } from 'react';
+
+interface SearchBarProps {
+  query: string;
+  onQueryChange: (value: string) => void;
+  onSubmit: () => void;
+}
+
+const SearchBar = ({ query, onQueryChange, onSubmit }: SearchBarProps) => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mx-auto flex w-full flex-col items-center gap-6 rounded-2xl bg-white p-8 shadow-xl"
+    >
+      <div className="w-full">
+        <label htmlFor="businessName" className="text-sm font-medium text-slate-600">
+          Nom de l'entreprise
+        </label>
+        <div className="mt-2 flex w-full flex-col gap-4 sm:flex-row">
+          <input
+            id="businessName"
+            type="text"
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Ex: Boulangerie Dupont Paris"
+            className="w-full flex-1 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-base text-slate-800 shadow-inner focus:border-amber-400 focus:outline-none focus:ring-4 focus:ring-amber-100"
+          />
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-xl bg-amber-500 px-6 py-3 text-base font-semibold text-slate-900 shadow-lg transition hover:bg-amber-400"
+          >
+            Générer
+          </button>
+        </div>
+      </div>
+      <p className="text-center text-sm text-slate-500">
+        Entrez le nom complet de l'entreprise tel qu'il apparaît sur Google Maps pour obtenir les informations les plus
+        précises.
+      </p>
+    </form>
+  );
+};
+
+export default SearchBar;

--- a/frontend/src/components/SitePreview.tsx
+++ b/frontend/src/components/SitePreview.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { BusinessInfo } from '../utils/template';
+
+interface SitePreviewProps {
+  html: string;
+  info: BusinessInfo;
+  onReset: () => void;
+}
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '') || 'landing-page';
+
+const SitePreview = ({ html, info, onReset }: SitePreviewProps) => {
+  const fileName = useMemo(() => `${slugify(info.name)}.html`, [info.name]);
+
+  const handleDownload = () => {
+    const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section className="mt-12 space-y-8">
+      <div className="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-md sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">Landing page prête</p>
+          <h2 className="mt-2 text-2xl font-semibold text-slate-900">{info.name}</h2>
+          <p className="mt-2 text-sm text-slate-600">{info.address}</p>
+          {typeof info.rating === 'number' && (
+            <p className="mt-1 text-sm text-slate-600">
+              Note Google : <span className="font-semibold text-amber-500">{info.rating.toFixed(1)}</span>
+              {typeof info.reviewCount === 'number' && ` · ${info.reviewCount} avis`}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="inline-flex items-center justify-center rounded-xl bg-amber-500 px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg transition hover:bg-amber-400"
+          >
+            Télécharger le HTML
+          </button>
+          <button
+            type="button"
+            onClick={onReset}
+            className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+          >
+            Nouveau projet
+          </button>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl shadow-2xl">
+        <iframe title={`Aperçu ${info.name}`} srcDoc={html} className="h-[720px] w-full border-0"></iframe>
+      </div>
+    </section>
+  );
+};
+
+export default SitePreview;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-body bg-slate-100 text-slate-800;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply font-display text-slate-900;
+}

--- a/frontend/src/utils/template.ts
+++ b/frontend/src/utils/template.ts
@@ -1,0 +1,232 @@
+export interface DayHours {
+  day: string;
+  hours: string | null;
+}
+
+export interface BusinessInfo {
+  name: string;
+  description: string;
+  category: string;
+  address: string;
+  phone: string;
+  rating: number | null;
+  reviewCount: number | null;
+  hours: DayHours[];
+  photoUrls: string[];
+  mapsUrl: string;
+}
+
+const FALLBACK_IMAGE =
+  'https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?auto=format&fit=crop&w=1600&q=80';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderHours(hours: DayHours[]): string {
+  if (!hours || hours.length === 0) {
+    return '<p class="text-slate-500">Horaires non disponibles pour le moment.</p>';
+  }
+
+  return `
+    <ul class="space-y-2">
+      ${hours
+        .map(
+          (item) => `
+            <li class="flex justify-between border-b border-slate-200 pb-2">
+              <span class="font-medium text-slate-700">${escapeHtml(item.day)}</span>
+              <span class="text-slate-600">${escapeHtml(item.hours ?? 'Fermé')}</span>
+            </li>
+          `
+        )
+        .join('')}
+    </ul>
+  `;
+}
+
+function renderGallery(urls: string[], businessName: string): string {
+  if (!urls || urls.length === 0) {
+    return `
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="relative overflow-hidden rounded-xl bg-slate-200 pt-[65%]"></div>
+        <div class="relative overflow-hidden rounded-xl bg-slate-200 pt-[65%]"></div>
+        <div class="relative overflow-hidden rounded-xl bg-slate-200 pt-[65%]"></div>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      ${urls
+        .map(
+          (url, index) => `
+            <div class="relative overflow-hidden rounded-xl shadow-sm pt-[65%]">
+              <img
+                src="${url}"
+                alt="Photo ${index + 1} de ${escapeHtml(businessName)}"
+                class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 hover:scale-105"
+                loading="lazy"
+              />
+            </div>
+          `
+        )
+        .join('')}
+    </div>
+  `;
+}
+
+export function populateTemplate(info: BusinessInfo): string {
+  const heroImage = info.photoUrls?.[0] ?? FALLBACK_IMAGE;
+  const aboutImage = info.photoUrls?.[1] ?? heroImage;
+  const galleryImages = info.photoUrls?.slice(2, 9) ?? [];
+
+  const rating =
+    typeof info.rating === 'number'
+      ? `<div class="mt-4 flex items-center gap-2 text-amber-500">
+          <span class="text-2xl font-semibold">${info.rating.toFixed(1)}</span>
+          <span class="text-sm text-slate-200">(${info.reviewCount ?? 'N/A'} avis)</span>
+        </div>`
+      : '';
+
+  const mapsEmbedUrl = info.address
+    ? `https://www.google.com/maps?q=${encodeURIComponent(info.address)}&output=embed`
+    : info.mapsUrl
+      ? `${info.mapsUrl}&output=embed`
+      : `https://www.google.com/maps?q=${encodeURIComponent(info.name)}&output=embed`;
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${escapeHtml(info.name)}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      body { font-family: 'Montserrat', sans-serif; background-color: #0f172a; }
+      h1, h2, h3, h4, h5, h6 { font-family: 'Playfair Display', serif; }
+    </style>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <header class="relative isolate overflow-hidden">
+      <div class="absolute inset-0">
+        <img src="${heroImage}" alt="${escapeHtml(info.name)}" class="h-full w-full object-cover" />
+        <div class="absolute inset-0 bg-slate-900/70"></div>
+      </div>
+      <div class="relative mx-auto flex min-h-[75vh] max-w-6xl flex-col justify-center px-6 py-24 text-center">
+        <span class="text-sm uppercase tracking-[0.5em] text-amber-400">${escapeHtml(info.category || 'Entreprise locale')}</span>
+        <h1 class="mt-6 text-4xl font-bold sm:text-5xl md:text-6xl">${escapeHtml(info.name)}</h1>
+        <p class="mx-auto mt-6 max-w-2xl text-lg text-slate-200">
+          ${escapeHtml(
+            info.description ||
+              "Découvrez l'excellence et le savoir-faire de notre équipe dédiée à votre satisfaction."
+          )}
+        </p>
+        <div class="mt-8 flex flex-wrap justify-center gap-4">
+          <a
+            href="tel:${escapeHtml(info.phone || '')}"
+            class="rounded-full bg-amber-500 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-slate-900 shadow-lg transition hover:bg-amber-400"
+          >
+            Nous appeler
+          </a>
+          <a
+            href="${info.mapsUrl}"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="rounded-full border border-amber-400 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-amber-400 transition hover:bg-amber-400 hover:text-slate-900"
+          >
+            Itinéraire
+          </a>
+        </div>
+        ${rating}
+      </div>
+    </header>
+
+    <main class="bg-slate-950">
+      <section class="mx-auto grid max-w-6xl gap-12 px-6 py-24 lg:grid-cols-2">
+        <div class="flex flex-col justify-center space-y-6">
+          <h2 class="text-3xl font-semibold text-amber-400">À propos</h2>
+          <p class="text-lg leading-relaxed text-slate-200">
+            ${escapeHtml(
+              info.description ||
+                "Nous mettons toute notre passion au service de nos clients en offrant des prestations sur mesure, réalisées avec soin et professionnalisme."
+            )}
+          </p>
+          <div class="rounded-2xl bg-slate-900/60 p-6">
+            <p class="text-sm uppercase tracking-[0.3em] text-amber-500">Coordonnées</p>
+            <p class="mt-4 flex items-start gap-3 text-slate-100">
+              <span class="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full bg-amber-500/20 text-amber-400">📍</span>
+              <span>${escapeHtml(info.address || 'Adresse non disponible')}</span>
+            </p>
+            <p class="mt-3 flex items-center gap-3 text-slate-100">
+              <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-amber-500/20 text-amber-400">📞</span>
+              <a href="tel:${escapeHtml(info.phone || '')}" class="hover:text-amber-400">
+                ${escapeHtml(info.phone || 'Téléphone non disponible')}
+              </a>
+            </p>
+          </div>
+        </div>
+        <div class="relative overflow-hidden rounded-3xl shadow-2xl">
+          <img src="${aboutImage}" alt="${escapeHtml(info.name)}" class="h-full w-full object-cover" />
+        </div>
+      </section>
+
+      <section class="bg-slate-900/60">
+        <div class="mx-auto max-w-6xl px-6 py-24">
+          <div class="flex flex-col items-start justify-between gap-6 pb-12 sm:flex-row sm:items-center">
+            <h2 class="text-3xl font-semibold text-amber-400">Galerie</h2>
+            <p class="max-w-xl text-slate-300">
+              Une sélection d'images reflétant l'ambiance et la qualité de ${escapeHtml(info.name)}.
+            </p>
+          </div>
+          ${renderGallery(galleryImages, info.name)}
+        </div>
+      </section>
+
+      <section class="mx-auto max-w-6xl px-6 py-24">
+        <div class="grid gap-12 lg:grid-cols-[2fr,3fr]">
+          <div class="rounded-3xl bg-slate-900/60 p-8 shadow-lg">
+            <h2 class="text-3xl font-semibold text-amber-400">Horaires</h2>
+            <p class="mt-3 text-slate-300">
+              Consultez nos disponibilités pour préparer votre prochaine visite.
+            </p>
+            <div class="mt-8 space-y-6">
+              ${renderHours(info.hours)}
+            </div>
+          </div>
+          <div class="overflow-hidden rounded-3xl shadow-xl">
+            <iframe
+              src="${mapsEmbedUrl}"
+              width="100%"
+              height="100%"
+              style="border:0; min-height: 420px;"
+              allowfullscreen=""
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+            ></iframe>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="border-t border-slate-800 bg-slate-950/80">
+      <div class="mx-auto flex max-w-6xl flex-col items-center justify-between gap-6 px-6 py-12 text-center sm:flex-row">
+        <p class="text-sm text-slate-400">© ${new Date().getFullYear()} ${escapeHtml(info.name)}. Tous droits réservés.</p>
+        <a href="${info.mapsUrl}" target="_blank" rel="noopener noreferrer" class="text-sm text-amber-400 hover:text-amber-300">
+          Voir sur Google Maps
+        </a>
+      </div>
+    </footer>
+  </body>
+</html>`;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        display: ['"Playfair Display"', 'serif'],
+        body: ['"Montserrat"', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    strictPort: true
+  }
+});


### PR DESCRIPTION
## Summary
- add an Express backend powered by Puppeteer to scrape Google Maps business details and expose them through `/api/generate-site`
- create a Vite + React + Tailwind frontend that requests the API, renders a landing page preview, and lets users download the HTML
- document repository setup and commands for installing dependencies and running both servers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfb33320a48332945b312d87064208